### PR TITLE
Fix Lockpick issue

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -566,7 +566,7 @@ QBCore.Functions.CreateCallback('jl-carboost:server:spawnCar', function (source,
       Wait(25)
    end
    if DoesEntityExist(car) then
-      SetVehicleDoorsLocked(car, 2) -- Lock the vehicle
+      SetVehicleDoorsLocked(car, 1) -- Lock the vehicle
       SetVehicleNumberPlateText(car, cardata.data.plate)
       SetVehicleColours(car, math.random(159))
       local netId = NetworkGetNetworkIdFromEntity(car)


### PR DESCRIPTION
When car boosting with friends, Once the contract owner lockpicks the car successfully it doesnt lock all the doors meaning you cant have a driver while you hack. This sets the doors to be unlocked.